### PR TITLE
Fixes 4647 edge case resulting in OOB

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -199,7 +199,7 @@ open class ChartDataSet: ChartBaseDataSet
         let match: (ChartDataEntry) -> Bool = { $0.x >= xValue }
         let i = partitioningIndex(where: match)
 
-        guard self[i].x == xValue else { return [] }
+        guard i < endIndex && self[i].x == xValue else { return [] }
         return self[i...].prefix(while: { $0.x == xValue })
     }
     


### PR DESCRIPTION
Fix 4647 bug when no matching paritiningIndex found (occurs when clicking to right of last plotted point)

### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->